### PR TITLE
Feature/sprint 1

### DIFF
--- a/docs/extractor/communication_contract_sequence.md
+++ b/docs/extractor/communication_contract_sequence.md
@@ -1,0 +1,41 @@
+# ETL MQTT Communication Contract v0.2
+
+```mermaid
+sequenceDiagram
+    title ETL MQTT Communication Contract v0.2
+    participant Orchestrator
+    participant Broker as MQTT Broker
+    participant Extract as Extract Service
+    participant Transform as Transform Service
+    participant Load as Load Service
+
+    Note over Orchestrator,Broker: Topics follow etl/{namespace}/{service}/{command_type}/{action}.<br/>Payloads are JSON and must include schemaVersion for versioned parsing.<br/>Orchestrator drives cmd/... topics; services emit event/{status}.
+
+    Orchestrator->>Broker: Subscribe etl/{ns}/*/event/status
+    Broker-->>Orchestrator: Subscription active
+    Extract->>Broker: Subscribe etl/{ns}/extract/cmd/*
+    Broker-->>Extract: Subscription active
+    Transform->>Broker: Subscribe etl/{ns}/transform/cmd/*
+    Broker-->>Transform: Subscription active
+    Load->>Broker: Subscribe etl/{ns}/load/cmd/*
+    Broker-->>Load: Subscription active
+
+    Orchestrator->>Broker: Publish etl/{ns}/extract/cmd/start\n(job_id,input.uri,options?)
+    Broker->>Extract: Deliver start command
+    Note right of Extract: Send status when starting, completing,<br/>and on failures. Periodic updates optional.
+    Extract->>Broker: Publish etl/{ns}/extract/event/running\nprogress?, stats?
+    Broker->>Orchestrator: Forward status update
+    Extract->>Broker: Publish etl/{ns}/extract/event/completed\ninclude output.uri
+    Extract->>Broker: Publish etl/{ns}/extract/event/failed\ninclude error.code/message
+    Broker->>Orchestrator: Forward completion / failure
+
+    Orchestrator->>Broker: Publish etl/{ns}/transform/cmd/start
+    Broker->>Transform: Deliver start command
+    Transform->>Broker: Publish event/running, event/completed,\nevent/failed topics as above
+    Broker->>Orchestrator: Forward status updates
+
+    Orchestrator->>Broker: Publish etl/{ns}/load/cmd/start
+    Broker->>Load: Deliver start command
+    Load->>Broker: Publish event/running, event/completed,\nevent/failed topics as above
+    Broker->>Orchestrator: Forward status updates
+```

--- a/docs/extractor/sprint-001-extract-workflow.md
+++ b/docs/extractor/sprint-001-extract-workflow.md
@@ -1,0 +1,372 @@
+# Sprint 001 Extract Workflow
+
+## Scope
+
+For sprint 001, the Extract layer does only one thing:
+
+1. Receive a single public link from the Orchestrator
+2. Download the file behind that link
+3. Upload the exact same file to the project bucket
+4. Return a new pre-signed URL pointing to the uploaded file
+
+Extract does not:
+
+- parse ICS
+- filter events
+- call any external business API
+- apply any business rule
+- transform the content
+
+If the input file is an ICS file, the output stored in the bucket is the same ICS file.
+
+## Functional Principle
+
+The Extract service is only a relay between:
+
+- the public source URL provided by the Orchestrator
+- the internal storage bucket used by the ETL pipeline
+
+The workflow is:
+
+`download(input.uri) -> upload(bucketPath, byte[]) -> share(bucketPath, expirationTime)`
+
+## MQTT Contract Mapping
+
+For sprint 001, Extract must follow the ETL MQTT communication contract.
+
+### Consumed topic
+
+```text
+etl/{namespace}/extract/cmd/start
+```
+
+### Produced topics
+
+```text
+etl/{namespace}/extract/event/running
+etl/{namespace}/extract/event/completed
+etl/{namespace}/extract/event/failed
+```
+
+### Required message rules
+
+- every message must contain `schemaVersion`
+- every message must contain `job_id`
+- the input public link is carried in `input.uri`
+- output is returned in `output.uri`
+
+### Mapping for Extract
+
+- `input.uri`: source public URL received from the Orchestrator
+- `output.uri`: new pre-signed URL generated after upload to the bucket
+- `options.destinationPath`: target object path in the bucket
+- `options.expirationTime`: validity duration of the returned pre-signed URL
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    autonumber
+
+    participant orchestrator as Orchestrator
+    participant broker as MQTT Broker
+    participant extract as Extract Service
+    participant source as Public File URL
+    participant bucket as Bucket Storage
+
+    orchestrator->>broker: Publish etl/{namespace}/extract/cmd/start
+    broker-->>extract: Consume start command
+
+    extract->>broker: Publish etl/{namespace}/extract/event/running
+    extract->>extract: Validate schemaVersion, job_id, input.uri
+
+    extract->>source: GET input.uri
+    source-->>extract: raw file bytes
+
+    extract->>bucket: upload(options.destinationPath, raw file bytes)
+    bucket-->>extract: upload ok
+
+    extract->>bucket: share(options.destinationPath, options.expirationTime)
+    bucket-->>extract: presigned URL
+
+    extract->>broker: Publish etl/{namespace}/extract/event/completed
+    broker-->>orchestrator: Deliver completion event
+
+    opt Technical error
+        extract->>broker: Publish etl/{namespace}/extract/event/failed
+        broker-->>orchestrator: Deliver failure event
+    end
+```
+
+## Command Payload
+
+The Orchestrator sends the start command on:
+
+```text
+etl/{namespace}/extract/cmd/start
+```
+
+Recommended sprint 001 payload:
+
+```json
+{
+  "schemaVersion": "1.0",
+  "job_id": "job-2026-03-12-001",
+  "input": {
+    "uri": "https://public.example.com/calendar.ics"
+  },
+  "options": {
+    "destinationPath": "raw/calendar/job-2026-03-12-001/calendar.ics",
+    "expirationTime": 3600
+  }
+}
+```
+
+### Fields used by Extract
+
+- `schemaVersion`: contract version
+- `job_id`: unique identifier for traceability
+- `input.uri`: public source link
+- `options.destinationPath`: bucket object path
+- `options.expirationTime`: pre-signed URL duration in seconds
+
+### Minimum validation
+
+Extract checks only technical constraints:
+
+- `schemaVersion` is present
+- `job_id` is present
+- `input` is present
+- `input.uri` is present
+- `options.destinationPath` is present
+- `options.expirationTime` is valid
+
+Extract does not inspect the business content of the file.
+
+## Event Payloads
+
+### Running event
+
+Topic:
+
+```text
+etl/{namespace}/extract/event/running
+```
+
+Example:
+
+```json
+{
+  "schemaVersion": "1.0",
+  "job_id": "job-2026-03-12-001",
+  "progress": 0,
+  "stats": {
+    "items_processed": 0,
+    "durationMs": 0
+  }
+}
+```
+
+This event must be published at least once when the job starts.
+
+### Completed event
+
+Topic:
+
+```text
+etl/{namespace}/extract/event/completed
+```
+
+Example:
+
+```json
+{
+  "schemaVersion": "1.0",
+  "job_id": "job-2026-03-12-001",
+  "output": {
+    "uri": "https://bucket.example.com/raw/calendar/job-2026-03-12-001/calendar.ics?signature=abc"
+  }
+}
+```
+
+This is the main success output of Extract in sprint 001.
+
+### Failed event
+
+Topic:
+
+```text
+etl/{namespace}/extract/event/failed
+```
+
+Example:
+
+```json
+{
+  "schemaVersion": "1.0",
+  "job_id": "job-2026-03-12-001",
+  "error": {
+    "code": "EXTRACT_DOWNLOAD_ERROR",
+    "message": "Unable to download source file"
+  }
+}
+```
+
+## Detailed Procedure
+
+### 1. Orchestrator publishes the start command
+
+The Orchestrator publishes a JSON payload on:
+
+```text
+etl/{namespace}/extract/cmd/start
+```
+
+The only mandatory business input for sprint 001 is the public URL in `input.uri`.
+
+### 2. Extract consumes and validates the command
+
+Extract reads the message and verifies:
+
+- contract fields are present
+- the source URL exists in `input.uri`
+- the bucket destination exists in `options.destinationPath`
+- the expiration time exists in `options.expirationTime`
+
+At this point, Extract publishes a `running` event.
+
+### 3. Extract downloads the source file
+
+Extract calls:
+
+```text
+download(input.uri)
+```
+
+Result:
+
+- the file is downloaded as raw bytes
+- the content is kept exactly as received
+
+There is no:
+
+- ICS parsing
+- event extraction
+- normalization
+- filtering
+
+### 4. Extract uploads the raw file to the bucket
+
+Extract calls:
+
+```text
+upload(options.destinationPath, fileBytes)
+```
+
+Result:
+
+- the exact same file is stored in the internal bucket
+- the object key is the agreed target path
+
+Recommended naming convention:
+
+```text
+raw/<source>/<job_id>/<filename>
+```
+
+Example:
+
+```text
+raw/calendar/job-2026-03-12-001/calendar.ics
+```
+
+### 5. Extract generates the new access URL
+
+Extract calls:
+
+```text
+share(options.destinationPath, options.expirationTime)
+```
+
+Result:
+
+- the bucket returns a new pre-signed URL
+- this URL is published in `output.uri`
+
+### 6. Extract publishes the final event
+
+On success, Extract publishes:
+
+```text
+etl/{namespace}/extract/event/completed
+```
+
+with:
+
+- `schemaVersion`
+- `job_id`
+- `output.uri`
+
+On failure, Extract publishes:
+
+```text
+etl/{namespace}/extract/event/failed
+```
+
+with:
+
+- `schemaVersion`
+- `job_id`
+- `error.code`
+- `error.message`
+
+## Operational Procedure
+
+### Orchestrator side
+
+1. Put the source ICS file behind a public URL or temporary signed URL.
+2. Build the MQTT command payload using `schemaVersion`, `job_id`, `input.uri`, and `options`.
+3. Publish the command on `etl/{namespace}/extract/cmd/start`.
+4. Wait for either `etl/{namespace}/extract/event/completed` or `etl/{namespace}/extract/event/failed`.
+
+### Extract side
+
+1. Subscribe to `etl/{namespace}/extract/cmd/start`.
+2. Consume the command message.
+3. Publish `etl/{namespace}/extract/event/running`.
+4. Download the file from `input.uri`.
+5. Upload the downloaded bytes to `options.destinationPath`.
+6. Generate a new pre-signed URL with `options.expirationTime`.
+7. Publish `etl/{namespace}/extract/event/completed` with `output.uri`.
+8. If an error occurs, publish `etl/{namespace}/extract/event/failed`.
+
+### Downstream side
+
+1. Read the completion event.
+2. Recover `output.uri`.
+3. Pass this URI to the next ETL stage when required.
+
+## Acceptance Criteria
+
+Sprint 001 is complete for Extract if:
+
+- Extract consumes `etl/{namespace}/extract/cmd/start`
+- Extract publishes at least one `event/running`
+- Extract downloads the file from `input.uri`
+- Extract uploads the exact same file to the bucket
+- Extract publishes `event/completed` with `output.uri`
+- Extract publishes `event/failed` on technical errors
+- Extract does not modify file content
+
+## Out of Scope
+
+The following belongs to later stages or later sprints:
+
+- reading ICS fields such as `UID`, `DTSTART`, or `DESCRIPTION`
+- converting ICS to JSON
+- generating SQL
+- billing logic
+- client detection through `[client]`
+- duration calculation
+- rate calculation
+- event filtering by date

--- a/docs/extractor/sprint-001-extract-workflow.md
+++ b/docs/extractor/sprint-001-extract-workflow.md
@@ -42,6 +42,11 @@ The workflow is:
 
 `download(sourceUrl) -> upload(destinationPath, byte[]) -> share(destinationPath, expirationTime)`
 
+This workflow can now be executed in two ways:
+
+- manually, by calling the existing endpoints one by one
+- directly, through a single endpoint that executes the complete chain
+
 ## Sequence Diagram
 
 ```mermaid
@@ -53,20 +58,31 @@ sequenceDiagram
     participant source as Public File URL
     participant bucket as Bucket Storage
 
-    caller->>extract: GET /api/objects/download?remote=sourceUrl
-    extract->>source: GET sourceUrl
-    source-->>extract: raw file bytes
-    extract-->>caller: raw file bytes
+    alt Manual 3-step flow
+        caller->>extract: GET /api/objects/download?remote=sourceUrl
+        extract->>source: GET sourceUrl
+        source-->>extract: raw file bytes
+        extract-->>caller: raw file bytes
 
-    caller->>extract: POST /api/objects
-    extract->>bucket: upload(destinationPath, raw file bytes)
-    bucket-->>extract: upload ok
-    extract-->>caller: 201 Created
+        caller->>extract: POST /api/objects
+        extract->>bucket: upload(destinationPath, raw file bytes)
+        bucket-->>extract: upload ok
+        extract-->>caller: 201 Created
 
-    caller->>extract: POST /api/objects/share?remote=destinationPath&expirationTime=3600
-    extract->>bucket: share(destinationPath, expirationTime)
-    bucket-->>extract: pre-signed URL
-    extract-->>caller: shared URL
+        caller->>extract: POST /api/objects/share?remote=destinationPath&expirationTime=3600
+        extract->>bucket: share(destinationPath, expirationTime)
+        bucket-->>extract: pre-signed URL
+        extract-->>caller: shared URL
+    else Single-call workflow endpoint
+        caller->>extract: POST /api/workflows/extract?sourceUrl=...&destinationRemote=...&expirationTime=...
+        extract->>source: GET sourceUrl
+        source-->>extract: raw file bytes
+        extract->>bucket: upload(destinationPath, raw file bytes)
+        bucket-->>extract: upload ok
+        extract->>bucket: share(destinationPath, expirationTime)
+        bucket-->>extract: pre-signed URL
+        extract-->>caller: shared URL
+    end
 ```
 
 ## Sprint 001 Input
@@ -194,6 +210,24 @@ curl -X POST --get \
   http://localhost:8080/api/objects/share
 ```
 
+## Single-Call Workflow Endpoint
+
+The same sprint 001 workflow can also be executed with one endpoint:
+
+```bash
+curl -X POST --get \
+  --data-urlencode "sourceUrl=https://public.example.com/calendar.ics" \
+  --data-urlencode "destinationRemote=my-bucket/raw/job-2026-03-12-001/calendar.ics" \
+  --data-urlencode "expirationTime=3600" \
+  http://localhost:8080/api/workflows/extract
+```
+
+Result:
+
+- Extract downloads the source file
+- Extract uploads the same bytes to the destination bucket path
+- Extract returns the final pre-signed URL directly
+
 ## Scripted Procedure
 
 The same workflow can be executed with the helper script:
@@ -237,6 +271,7 @@ Sprint 001 is complete for Extract if:
 - Extract returns a new pre-signed URL
 - Extract does not modify file content
 - Extract can be executed manually with the current REST API
+- Extract can be executed through the single workflow endpoint
 
 ## Out of Scope
 

--- a/docs/extractor/sprint-001-extract-workflow.md
+++ b/docs/extractor/sprint-001-extract-workflow.md
@@ -4,7 +4,7 @@
 
 For sprint 001, the Extract layer does only one thing:
 
-1. Receive a single public link from the Orchestrator
+1. Receive a single public link
 2. Download the file behind that link
 3. Upload the exact same file to the project bucket
 4. Return a new pre-signed URL pointing to the uploaded file
@@ -16,51 +16,31 @@ Extract does not:
 - call any external business API
 - apply any business rule
 - transform the content
+- use MQTT for this sprint
 
 If the input file is an ICS file, the output stored in the bucket is the same ICS file.
+
+## Sprint 001 Objective
+
+The goal of sprint 001 is to validate the minimal Extract responsibility:
+
+- accept a public or pre-signed URL as input
+- retrieve the raw file bytes
+- store the same bytes in the target bucket
+- make the uploaded file available through a new pre-signed URL
+
+This sprint is a technical relay only. It is not yet the final orchestrated ETL communication model.
 
 ## Functional Principle
 
 The Extract service is only a relay between:
 
-- the public source URL provided by the Orchestrator
+- the public source URL provided for the file
 - the internal storage bucket used by the ETL pipeline
 
 The workflow is:
 
-`download(input.uri) -> upload(bucketPath, byte[]) -> share(bucketPath, expirationTime)`
-
-## MQTT Contract Mapping
-
-For sprint 001, Extract must follow the ETL MQTT communication contract.
-
-### Consumed topic
-
-```text
-etl/{namespace}/extract/cmd/start
-```
-
-### Produced topics
-
-```text
-etl/{namespace}/extract/event/running
-etl/{namespace}/extract/event/completed
-etl/{namespace}/extract/event/failed
-```
-
-### Required message rules
-
-- every message must contain `schemaVersion`
-- every message must contain `job_id`
-- the input public link is carried in `input.uri`
-- output is returned in `output.uri`
-
-### Mapping for Extract
-
-- `input.uri`: source public URL received from the Orchestrator
-- `output.uri`: new pre-signed URL generated after upload to the bucket
-- `options.destinationPath`: target object path in the bucket
-- `options.expirationTime`: validity duration of the returned pre-signed URL
+`download(sourceUrl) -> upload(destinationPath, byte[]) -> share(destinationPath, expirationTime)`
 
 ## Sequence Diagram
 
@@ -68,184 +48,70 @@ etl/{namespace}/extract/event/failed
 sequenceDiagram
     autonumber
 
-    participant orchestrator as Orchestrator
-    participant broker as MQTT Broker
-    participant extract as Extract Service
+    participant caller as Caller / Script
+    participant extract as Extract API
     participant source as Public File URL
     participant bucket as Bucket Storage
 
-    orchestrator->>broker: Publish etl/{namespace}/extract/cmd/start
-    broker-->>extract: Consume start command
-
-    extract->>broker: Publish etl/{namespace}/extract/event/running
-    extract->>extract: Validate schemaVersion, job_id, input.uri
-
-    extract->>source: GET input.uri
+    caller->>extract: GET /api/objects/download?remote=sourceUrl
+    extract->>source: GET sourceUrl
     source-->>extract: raw file bytes
+    extract-->>caller: raw file bytes
 
-    extract->>bucket: upload(options.destinationPath, raw file bytes)
+    caller->>extract: POST /api/objects
+    extract->>bucket: upload(destinationPath, raw file bytes)
     bucket-->>extract: upload ok
+    extract-->>caller: 201 Created
 
-    extract->>bucket: share(options.destinationPath, options.expirationTime)
-    bucket-->>extract: presigned URL
-
-    extract->>broker: Publish etl/{namespace}/extract/event/completed
-    broker-->>orchestrator: Deliver completion event
-
-    opt Technical error
-        extract->>broker: Publish etl/{namespace}/extract/event/failed
-        broker-->>orchestrator: Deliver failure event
-    end
+    caller->>extract: POST /api/objects/share?remote=destinationPath&expirationTime=3600
+    extract->>bucket: share(destinationPath, expirationTime)
+    bucket-->>extract: pre-signed URL
+    extract-->>caller: shared URL
 ```
 
-## Command Payload
+## Sprint 001 Input
 
-The Orchestrator sends the start command on:
+For this sprint, the minimum useful input is:
+
+- `sourceUrl`: public or pre-signed URL of the source file
+- `destinationPath`: target object path in the bucket
+- `expirationTime`: validity duration of the returned shared URL
+
+Example values:
 
 ```text
-etl/{namespace}/extract/cmd/start
-```
-
-Recommended sprint 001 payload:
-
-```json
-{
-  "schemaVersion": "1.0",
-  "job_id": "job-2026-03-12-001",
-  "input": {
-    "uri": "https://public.example.com/calendar.ics"
-  },
-  "options": {
-    "destinationPath": "raw/calendar/job-2026-03-12-001/calendar.ics",
-    "expirationTime": 3600
-  }
-}
-```
-
-### Fields used by Extract
-
-- `schemaVersion`: contract version
-- `job_id`: unique identifier for traceability
-- `input.uri`: public source link
-- `options.destinationPath`: bucket object path
-- `options.expirationTime`: pre-signed URL duration in seconds
-
-### Minimum validation
-
-Extract checks only technical constraints:
-
-- `schemaVersion` is present
-- `job_id` is present
-- `input` is present
-- `input.uri` is present
-- `options.destinationPath` is present
-- `options.expirationTime` is valid
-
-Extract does not inspect the business content of the file.
-
-## Event Payloads
-
-### Running event
-
-Topic:
-
-```text
-etl/{namespace}/extract/event/running
-```
-
-Example:
-
-```json
-{
-  "schemaVersion": "1.0",
-  "job_id": "job-2026-03-12-001",
-  "progress": 0,
-  "stats": {
-    "items_processed": 0,
-    "durationMs": 0
-  }
-}
-```
-
-This event must be published at least once when the job starts.
-
-### Completed event
-
-Topic:
-
-```text
-etl/{namespace}/extract/event/completed
-```
-
-Example:
-
-```json
-{
-  "schemaVersion": "1.0",
-  "job_id": "job-2026-03-12-001",
-  "output": {
-    "uri": "https://bucket.example.com/raw/calendar/job-2026-03-12-001/calendar.ics?signature=abc"
-  }
-}
-```
-
-This is the main success output of Extract in sprint 001.
-
-### Failed event
-
-Topic:
-
-```text
-etl/{namespace}/extract/event/failed
-```
-
-Example:
-
-```json
-{
-  "schemaVersion": "1.0",
-  "job_id": "job-2026-03-12-001",
-  "error": {
-    "code": "EXTRACT_DOWNLOAD_ERROR",
-    "message": "Unable to download source file"
-  }
-}
+sourceUrl=https://public.example.com/calendar.ics
+destinationPath=my-bucket/raw/job-2026-03-12-001/calendar.ics
+expirationTime=3600
 ```
 
 ## Detailed Procedure
 
-### 1. Orchestrator publishes the start command
+### 1. Receive the public link
 
-The Orchestrator publishes a JSON payload on:
+The source file is made available through a public or pre-signed URL.
+
+Example:
 
 ```text
-etl/{namespace}/extract/cmd/start
+https://public.example.com/calendar.ics
 ```
 
-The only mandatory business input for sprint 001 is the public URL in `input.uri`.
+At sprint 001 level, this link can be provided manually.
 
-### 2. Extract consumes and validates the command
+### 2. Download the source file
 
-Extract reads the message and verifies:
+Extract downloads the file from the provided URL.
 
-- contract fields are present
-- the source URL exists in `input.uri`
-- the bucket destination exists in `options.destinationPath`
-- the expiration time exists in `options.expirationTime`
-
-At this point, Extract publishes a `running` event.
-
-### 3. Extract downloads the source file
-
-Extract calls:
+Logical action:
 
 ```text
-download(input.uri)
+download(sourceUrl)
 ```
 
 Result:
 
-- the file is downloaded as raw bytes
+- the file is retrieved as raw bytes
 - the content is kept exactly as received
 
 There is no:
@@ -255,12 +121,14 @@ There is no:
 - normalization
 - filtering
 
-### 4. Extract uploads the raw file to the bucket
+### 3. Upload the raw file to the bucket
 
-Extract calls:
+Extract uploads the downloaded bytes to the chosen bucket path.
+
+Logical action:
 
 ```text
-upload(options.destinationPath, fileBytes)
+upload(destinationPath, fileBytes)
 ```
 
 Result:
@@ -280,88 +148,101 @@ Example:
 raw/calendar/job-2026-03-12-001/calendar.ics
 ```
 
-### 5. Extract generates the new access URL
+### 4. Generate the new access URL
 
-Extract calls:
+Extract generates a new shared URL for the uploaded object.
+
+Logical action:
 
 ```text
-share(options.destinationPath, options.expirationTime)
+share(destinationPath, expirationTime)
 ```
 
 Result:
 
 - the bucket returns a new pre-signed URL
-- this URL is published in `output.uri`
+- this URL is the main output of sprint 001 for the Extract layer
 
-### 6. Extract publishes the final event
+## Manual REST Procedure
 
-On success, Extract publishes:
+For sprint 001, the workflow can be tested manually with the existing REST API.
 
-```text
-etl/{namespace}/extract/event/completed
+### Step 1. Download the file through Extract
+
+```bash
+curl --get \
+  --data-urlencode "remote=https://public.example.com/calendar.ics" \
+  http://localhost:8080/api/objects/download \
+  --output calendar.ics
 ```
 
-with:
+### Step 2. Upload the same file to the bucket
 
-- `schemaVersion`
-- `job_id`
-- `output.uri`
-
-On failure, Extract publishes:
-
-```text
-etl/{namespace}/extract/event/failed
+```bash
+curl -X POST \
+  -F "remote=my-bucket/raw/job-2026-03-12-001/calendar.ics" \
+  -F "file=@calendar.ics" \
+  http://localhost:8080/api/objects
 ```
 
-with:
+### Step 3. Request the shared URL
 
-- `schemaVersion`
-- `job_id`
-- `error.code`
-- `error.message`
+```bash
+curl -X POST --get \
+  --data-urlencode "remote=my-bucket/raw/job-2026-03-12-001/calendar.ics" \
+  --data-urlencode "expirationTime=3600" \
+  http://localhost:8080/api/objects/share
+```
 
-## Operational Procedure
+## Scripted Procedure
 
-### Orchestrator side
+The same workflow can be executed with the helper script:
 
-1. Put the source ICS file behind a public URL or temporary signed URL.
-2. Build the MQTT command payload using `schemaVersion`, `job_id`, `input.uri`, and `options`.
-3. Publish the command on `etl/{namespace}/extract/cmd/start`.
-4. Wait for either `etl/{namespace}/extract/event/completed` or `etl/{namespace}/extract/event/failed`.
+```bash
+bash scripts/manual_extract_workflow.sh \
+  "https://public.example.com/calendar.ics" \
+  "my-bucket/raw/job-2026-03-12-001/calendar.ics" \
+  3600 \
+  "http://localhost:8080/api"
+```
 
-### Extract side
+## Validation Rules
 
-1. Subscribe to `etl/{namespace}/extract/cmd/start`.
-2. Consume the command message.
-3. Publish `etl/{namespace}/extract/event/running`.
-4. Download the file from `input.uri`.
-5. Upload the downloaded bytes to `options.destinationPath`.
-6. Generate a new pre-signed URL with `options.expirationTime`.
-7. Publish `etl/{namespace}/extract/event/completed` with `output.uri`.
-8. If an error occurs, publish `etl/{namespace}/extract/event/failed`.
+For sprint 001, Extract verifies only technical constraints:
 
-### Downstream side
+- the source URL is present
+- the destination path is present
+- the destination path targets an object, not just a bucket root
+- the expiration time is valid
 
-1. Read the completion event.
-2. Recover `output.uri`.
-3. Pass this URI to the next ETL stage when required.
+Extract does not inspect the business content of the file.
+
+## Output
+
+The expected output of sprint 001 is a new pre-signed URL for the uploaded object.
+
+Example:
+
+```text
+https://bucket.example.com/raw/job-2026-03-12-001/calendar.ics?signature=abc
+```
 
 ## Acceptance Criteria
 
 Sprint 001 is complete for Extract if:
 
-- Extract consumes `etl/{namespace}/extract/cmd/start`
-- Extract publishes at least one `event/running`
-- Extract downloads the file from `input.uri`
+- Extract accepts one public link as input
+- Extract downloads the file successfully
 - Extract uploads the exact same file to the bucket
-- Extract publishes `event/completed` with `output.uri`
-- Extract publishes `event/failed` on technical errors
+- Extract returns a new pre-signed URL
 - Extract does not modify file content
+- Extract can be executed manually with the current REST API
 
 ## Out of Scope
 
 The following belongs to later stages or later sprints:
 
+- MQTT-based orchestration
 - reading ICS fields such as `UID`, `DTSTART`, or `DESCRIPTION`
 - converting ICS to JSON
 - generating SQL

--- a/docs/extractor/sprint-001-extract-workflow.md
+++ b/docs/extractor/sprint-001-extract-workflow.md
@@ -45,7 +45,7 @@ The workflow is:
 This workflow can now be executed in two ways:
 
 - manually, by calling the existing endpoints one by one
-- directly, through a single endpoint that executes the complete chain
+- directly, through a single endpoint that executes the complete chain with the server-side default share expiration
 
 ## Sequence Diagram
 
@@ -74,12 +74,12 @@ sequenceDiagram
         bucket-->>extract: pre-signed URL
         extract-->>caller: shared URL
     else Single-call workflow endpoint
-        caller->>extract: POST /api/workflows/extract?sourceUrl=...&destinationRemote=...&expirationTime=...
+        caller->>extract: POST /api/workflows/extract?sourceUrl=...&destinationRemote=...
         extract->>source: GET sourceUrl
         source-->>extract: raw file bytes
         extract->>bucket: upload(destinationPath, raw file bytes)
         bucket-->>extract: upload ok
-        extract->>bucket: share(destinationPath, expirationTime)
+        extract->>bucket: share(destinationPath, defaultExpirationTime)
         bucket-->>extract: pre-signed URL
         extract-->>caller: shared URL
     end
@@ -91,7 +91,7 @@ For this sprint, the minimum useful input is:
 
 - `sourceUrl`: public or pre-signed URL of the source file
 - `destinationPath`: target object path in the bucket
-- `expirationTime`: validity duration of the returned shared URL
+- `expirationTime`: validity duration of the returned shared URL when using the manual `share` endpoint
 
 Example values:
 
@@ -178,6 +178,7 @@ Result:
 
 - the bucket returns a new pre-signed URL
 - this URL is the main output of sprint 001 for the Extract layer
+- for the single workflow endpoint, `expirationTime` is taken from server configuration instead of the request
 
 ## Manual REST Procedure
 
@@ -218,7 +219,6 @@ The same sprint 001 workflow can also be executed with one endpoint:
 curl -X POST --get \
   --data-urlencode "sourceUrl=https://public.example.com/calendar.ics" \
   --data-urlencode "destinationRemote=my-bucket/raw/job-2026-03-12-001/calendar.ics" \
-  --data-urlencode "expirationTime=3600" \
   http://localhost:8080/api/workflows/extract
 ```
 
@@ -227,6 +227,7 @@ Result:
 - Extract downloads the source file
 - Extract uploads the same bytes to the destination bucket path
 - Extract returns the final pre-signed URL directly
+- the share expiration is resolved server-side from `WORKFLOW_SHARE_EXPIRATION_TIME` and defaults to `3600`
 
 ## Scripted Procedure
 
@@ -247,7 +248,7 @@ For sprint 001, Extract verifies only technical constraints:
 - the source URL is present
 - the destination path is present
 - the destination path targets an object, not just a bucket root
-- the expiration time is valid
+- for the manual `share` endpoint, the expiration time is valid
 
 Extract does not inspect the business content of the file.
 

--- a/scripts/manual_extract_workflow.sh
+++ b/scripts/manual_extract_workflow.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage:
+  manual_extract_workflow.sh <source_url> <destination_remote> [expiration_time] [api_base_url]
+
+Arguments:
+  source_url          Public or pre-signed URL of the source file
+  destination_remote  Bucket destination in the form bucket/key
+  expiration_time     Share link expiration in seconds (default: 3600)
+  api_base_url        Base URL of the API (default: http://localhost:8080/api)
+
+Example:
+  ./scripts/manual_extract_workflow.sh \
+    "https://public.example.com/calendar.ics?signature=abc" \
+    "my-bucket/raw/job-123/calendar.ics" \
+    3600 \
+    "http://localhost:8080/api"
+EOF
+}
+
+if [[ $# -lt 2 || $# -gt 4 ]]; then
+    usage
+    exit 1
+fi
+
+SOURCE_URL="$1"
+DESTINATION_REMOTE="$2"
+EXPIRATION_TIME="${3:-3600}"
+API_BASE_URL="${4:-http://localhost:8080/api}"
+
+TEMP_FILE="$(mktemp /tmp/extract-workflow.XXXXXX)"
+
+cleanup() {
+    rm -f "$TEMP_FILE"
+}
+
+trap cleanup EXIT
+
+echo "1. Downloading source file through the Extract API..."
+curl --fail --silent --show-error \
+    --get \
+    --data-urlencode "remote=${SOURCE_URL}" \
+    "${API_BASE_URL}/objects/download" \
+    --output "$TEMP_FILE"
+
+FILE_SIZE="$(wc -c < "$TEMP_FILE" | tr -d ' ')"
+echo "   Downloaded ${FILE_SIZE} bytes"
+
+echo "2. Uploading file to bucket destination ${DESTINATION_REMOTE}..."
+curl --fail --silent --show-error \
+    -X POST \
+    -F "remote=${DESTINATION_REMOTE}" \
+    -F "file=@${TEMP_FILE}" \
+    "${API_BASE_URL}/objects"
+
+echo "   Upload completed"
+
+echo "3. Requesting a shared URL..."
+SHARED_URL="$(
+    curl --fail --silent --show-error \
+        -X POST \
+        --get \
+        --data-urlencode "remote=${DESTINATION_REMOTE}" \
+        --data-urlencode "expirationTime=${EXPIRATION_TIME}" \
+        "${API_BASE_URL}/objects/share"
+)"
+
+echo
+echo "Workflow completed"
+echo "Shared URL:"
+echo "${SHARED_URL}"

--- a/scripts/manual_extract_workflow.sh
+++ b/scripts/manual_extract_workflow.sh
@@ -32,6 +32,11 @@ DESTINATION_REMOTE="$2"
 EXPIRATION_TIME="${3:-3600}"
 API_BASE_URL="${4:-http://localhost:8080/api}"
 
+if [[ ! "${SOURCE_URL}" =~ ^https?:// ]]; then
+    echo "source_url must start with http:// or https://"
+    exit 1
+fi
+
 TEMP_FILE="$(mktemp /tmp/extract-workflow.XXXXXX)"
 
 cleanup() {

--- a/src/main/java/com/example/extractorservice/adapter/impl/AwsAdapterImpl.java
+++ b/src/main/java/com/example/extractorservice/adapter/impl/AwsAdapterImpl.java
@@ -10,6 +10,7 @@ import com.example.extractorservice.adapter.ExtractorAdapter;
 import com.example.extractorservice.exception.BucketObjectNotFoundException;
 import com.example.extractorservice.exception.BucketOperationException;
 import com.example.extractorservice.helper.AdapterHelper;
+import com.example.extractorservice.helper.RemoteDownloadHelper;
 
 import static com.example.extractorservice.helper.ConfigHelper.getConfig;
 import static com.example.extractorservice.helper.AdapterHelper.validateExpiration;
@@ -85,6 +86,10 @@ public class AwsAdapterImpl implements ExtractorAdapter {
 
     @Override
     public byte[] download(String remoteSrc) {
+        if (RemoteDownloadHelper.isHttpUrl(remoteSrc)) {
+            return RemoteDownloadHelper.download(remoteSrc);
+        }
+
         validateRemoteSrc(remoteSrc);
 
         BucketSrc bucketSrc = AdapterHelper.extractBucketAndKey(remoteSrc);

--- a/src/main/java/com/example/extractorservice/adapter/impl/AwsAdapterImpl.java
+++ b/src/main/java/com/example/extractorservice/adapter/impl/AwsAdapterImpl.java
@@ -3,6 +3,7 @@
  */
 package com.example.extractorservice.adapter.impl;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
@@ -45,6 +46,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 @Component("AWS")
+@ConditionalOnProperty(name = "PROVIDER_IMPL", havingValue = "AWS")
 @Profile("!test")
 public class AwsAdapterImpl implements ExtractorAdapter {
 

--- a/src/main/java/com/example/extractorservice/adapter/impl/AzureAdapterImpl.java
+++ b/src/main/java/com/example/extractorservice/adapter/impl/AzureAdapterImpl.java
@@ -1,5 +1,6 @@
 package com.example.extractorservice.adapter.impl;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import com.example.extractorservice.adapter.ExtractorAdapter;
@@ -7,6 +8,7 @@ import com.example.extractorservice.adapter.ExtractorAdapter;
 import java.util.List;
 
 @Component("AZURE")
+@ConditionalOnProperty(name = "PROVIDER_IMPL", havingValue = "AZURE")
 public class AzureAdapterImpl implements ExtractorAdapter {
 
     @Override

--- a/src/main/java/com/example/extractorservice/adapter/impl/GcpAdapterImpl.java
+++ b/src/main/java/com/example/extractorservice/adapter/impl/GcpAdapterImpl.java
@@ -7,6 +7,7 @@ import com.example.extractorservice.adapter.ExtractorAdapter;
 import com.example.extractorservice.exception.BucketObjectNotFoundException;
 import com.example.extractorservice.exception.BucketOperationException;
 import com.example.extractorservice.helper.AdapterHelper;
+import com.example.extractorservice.helper.RemoteDownloadHelper;
 
 import static com.example.extractorservice.helper.ConfigHelper.getConfig;
 import static com.example.extractorservice.helper.AdapterHelper.validateExpiration;
@@ -69,6 +70,10 @@ public class GcpAdapterImpl implements ExtractorAdapter {
 
     @Override
     public byte[] download(final String remoteSrc) {
+        if (RemoteDownloadHelper.isHttpUrl(remoteSrc)) {
+            return RemoteDownloadHelper.download(remoteSrc);
+        }
+
         BucketSrc bucketSrc = AdapterHelper.extractBucketAndKey(remoteSrc);
 
         try {

--- a/src/main/java/com/example/extractorservice/adapter/impl/GcpAdapterImpl.java
+++ b/src/main/java/com/example/extractorservice/adapter/impl/GcpAdapterImpl.java
@@ -23,6 +23,7 @@ import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
@@ -34,6 +35,7 @@ import java.util.List;
 import java.util.stream.StreamSupport;
 
 @Component("GCP")
+@ConditionalOnProperty(name = "PROVIDER_IMPL", havingValue = "GCP")
 @Profile("!test")
 public class GcpAdapterImpl implements ExtractorAdapter {
 

--- a/src/main/java/com/example/extractorservice/controller/ExtractController.java
+++ b/src/main/java/com/example/extractorservice/controller/ExtractController.java
@@ -184,4 +184,30 @@ public class ExtractController {
             @Parameter(description = "Expiration time in seconds", example = "3600") @RequestParam int expirationTime) {
         return extractorService.share(remote, expirationTime);
     }
+
+    /**
+     * Execute the complete sprint 1 extract workflow:
+     * download a file from a public or pre-signed URL,
+     * upload the same bytes to the bucket,
+     * then return a new shared URL.
+     *
+     * @param sourceUrl         public or pre-signed source URL
+     * @param destinationRemote destination path in the bucket
+     * @param expirationTime    shared URL expiration in seconds
+     * @return shared URL for the uploaded file
+     */
+    @Operation(summary = "Execute the complete sprint 1 extract workflow", description = "Downloads a file from a public or pre-signed URL, uploads it to the bucket, then returns the new shared URL")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Workflow completed successfully"),
+            @ApiResponse(responseCode = "400", description = "Invalid request parameters", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Source object not found", content = @Content),
+            @ApiResponse(responseCode = "500", description = "Internal server error", content = @Content)
+    })
+    @PostMapping(value = "/workflows/extract", params = { "sourceUrl", "destinationRemote", "expirationTime" })
+    public String executeWorkflow(
+            @Parameter(description = "Public or pre-signed source URL", required = true) @RequestParam String sourceUrl,
+            @Parameter(description = "Destination object path in the bucket", required = true) @RequestParam String destinationRemote,
+            @Parameter(description = "Expiration time in seconds", example = "3600") @RequestParam int expirationTime) {
+        return extractorService.executeWorkflow(sourceUrl, destinationRemote, expirationTime);
+    }
 }

--- a/src/main/java/com/example/extractorservice/controller/ExtractController.java
+++ b/src/main/java/com/example/extractorservice/controller/ExtractController.java
@@ -193,7 +193,6 @@ public class ExtractController {
      *
      * @param sourceUrl         public or pre-signed source URL
      * @param destinationRemote destination path in the bucket
-     * @param expirationTime    shared URL expiration in seconds
      * @return shared URL for the uploaded file
      */
     @Operation(summary = "Execute the complete sprint 1 extract workflow", description = "Downloads a file from a public or pre-signed URL, uploads it to the bucket, then returns the new shared URL")
@@ -203,11 +202,10 @@ public class ExtractController {
             @ApiResponse(responseCode = "404", description = "Source object not found", content = @Content),
             @ApiResponse(responseCode = "500", description = "Internal server error", content = @Content)
     })
-    @PostMapping(value = "/workflows/extract", params = { "sourceUrl", "destinationRemote", "expirationTime" })
+    @PostMapping(value = "/workflows/extract", params = { "sourceUrl", "destinationRemote" })
     public String executeWorkflow(
             @Parameter(description = "Public or pre-signed source URL", required = true) @RequestParam String sourceUrl,
-            @Parameter(description = "Destination object path in the bucket", required = true) @RequestParam String destinationRemote,
-            @Parameter(description = "Expiration time in seconds", example = "3600") @RequestParam int expirationTime) {
-        return extractorService.executeWorkflow(sourceUrl, destinationRemote, expirationTime);
+            @Parameter(description = "Destination object path in the bucket", required = true) @RequestParam String destinationRemote) {
+        return extractorService.executeWorkflow(sourceUrl, destinationRemote);
     }
 }

--- a/src/main/java/com/example/extractorservice/helper/RemoteDownloadHelper.java
+++ b/src/main/java/com/example/extractorservice/helper/RemoteDownloadHelper.java
@@ -1,0 +1,74 @@
+package com.example.extractorservice.helper;
+
+import static com.example.extractorservice.helper.AdapterHelper.validateRemoteSrc;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+import com.example.extractorservice.exception.BucketObjectNotFoundException;
+import com.example.extractorservice.exception.BucketOperationException;
+
+public final class RemoteDownloadHelper {
+
+    private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(30);
+
+    private RemoteDownloadHelper() {
+    }
+
+    public static boolean isHttpUrl(String remoteSrc) {
+        validateRemoteSrc(remoteSrc);
+
+        try {
+            URI uri = URI.create(remoteSrc.trim());
+            String scheme = uri.getScheme();
+            return "http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme);
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    public static byte[] download(String remoteSrc) {
+        validateRemoteSrc(remoteSrc);
+
+        try {
+            HttpRequest request = HttpRequest.newBuilder(URI.create(remoteSrc.trim()))
+                    .GET()
+                    .timeout(REQUEST_TIMEOUT)
+                    .build();
+
+            HttpResponse<byte[]> response = HTTP_CLIENT.send(
+                    request,
+                    HttpResponse.BodyHandlers.ofByteArray());
+
+            if (response.statusCode() >= 200 && response.statusCode() < 300) {
+                return response.body();
+            }
+
+            if (response.statusCode() == 404) {
+                throw new BucketObjectNotFoundException(remoteSrc);
+            }
+
+            throw new BucketOperationException(
+                    "Error downloading object from pre-signed URL "
+                            + remoteSrc
+                            + " (HTTP "
+                            + response.statusCode()
+                            + ")",
+                    null);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new BucketOperationException(
+                    "Interrupted while downloading object from pre-signed URL " + remoteSrc,
+                    e);
+        } catch (IOException | IllegalArgumentException e) {
+            throw new BucketOperationException(
+                    "Error downloading object from pre-signed URL " + remoteSrc,
+                    e);
+        }
+    }
+}

--- a/src/main/java/com/example/extractorservice/service/ExtractorService.java
+++ b/src/main/java/com/example/extractorservice/service/ExtractorService.java
@@ -51,4 +51,10 @@ public class ExtractorService {
     public String share(String remote, int expirationTime) {
         return adapter.share(remote, expirationTime);
     }
+
+    public String executeWorkflow(String sourceUrl, String destinationRemote, int expirationTime) {
+        byte[] content = adapter.download(sourceUrl);
+        adapter.upload(destinationRemote, content);
+        return adapter.share(destinationRemote, expirationTime);
+    }
 }

--- a/src/main/java/com/example/extractorservice/service/ExtractorService.java
+++ b/src/main/java/com/example/extractorservice/service/ExtractorService.java
@@ -12,6 +12,8 @@ import java.util.List;
 @Service
 public class ExtractorService {
 
+    private static final int DEFAULT_WORKFLOW_EXPIRATION_TIME = 3600;
+
     private final ExtractorServiceFactory factory;
     private ExtractorAdapter adapter;
 
@@ -52,9 +54,9 @@ public class ExtractorService {
         return adapter.share(remote, expirationTime);
     }
 
-    public String executeWorkflow(String sourceUrl, String destinationRemote, int expirationTime) {
+    public String executeWorkflow(String sourceUrl, String destinationRemote) {
         byte[] content = adapter.download(sourceUrl);
         adapter.upload(destinationRemote, content);
-        return adapter.share(destinationRemote, expirationTime);
+        return adapter.share(destinationRemote, DEFAULT_WORKFLOW_EXPIRATION_TIME);
     }
 }

--- a/src/test/java/com/example/extractorservice/helper/RemoteDownloadHelperTest.java
+++ b/src/test/java/com/example/extractorservice/helper/RemoteDownloadHelperTest.java
@@ -1,0 +1,98 @@
+package com.example.extractorservice.helper;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.example.extractorservice.exception.BucketObjectNotFoundException;
+import com.example.extractorservice.exception.BucketOperationException;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+class RemoteDownloadHelperTest {
+
+    private HttpServer server;
+    private String baseUrl;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.start();
+        baseUrl = "http://localhost:" + server.getAddress().getPort();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void isHttpUrl_shouldReturnTrue_forHttpUrl() {
+        assertTrue(RemoteDownloadHelper.isHttpUrl(baseUrl + "/file"));
+    }
+
+    @Test
+    void isHttpUrl_shouldReturnFalse_forBucketPath() {
+        assertFalse(RemoteDownloadHelper.isHttpUrl("my-bucket/path/file.csv"));
+    }
+
+    @Test
+    void download_shouldReturnResponseBody_whenEndpointReturnsSuccess() {
+        byte[] expected = "order-id,amount\n1,42\n".getBytes(StandardCharsets.UTF_8);
+        server.createContext("/file", new FixedResponseHandler(200, expected));
+
+        byte[] result = RemoteDownloadHelper.download(baseUrl + "/file");
+
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    void download_shouldThrowBucketObjectNotFoundException_whenEndpointReturns404() {
+        server.createContext("/missing", new FixedResponseHandler(404, new byte[0]));
+
+        assertThrows(
+                BucketObjectNotFoundException.class,
+                () -> RemoteDownloadHelper.download(baseUrl + "/missing"));
+    }
+
+    @Test
+    void download_shouldThrowBucketOperationException_whenEndpointReturnsNonSuccess() {
+        server.createContext("/error", new FixedResponseHandler(500, "boom".getBytes(StandardCharsets.UTF_8)));
+
+        assertThrows(
+                BucketOperationException.class,
+                () -> RemoteDownloadHelper.download(baseUrl + "/error"));
+    }
+
+    private static final class FixedResponseHandler implements HttpHandler {
+
+        private final int statusCode;
+        private final byte[] body;
+
+        private FixedResponseHandler(int statusCode, byte[] body) {
+            this.statusCode = statusCode;
+            this.body = body;
+        }
+
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            exchange.sendResponseHeaders(statusCode, body.length);
+            try (OutputStream outputStream = exchange.getResponseBody()) {
+                outputStream.write(body);
+            }
+        }
+    }
+}

--- a/src/test/java/com/example/extractorservice/service/ExtractorServiceWorkflowTest.java
+++ b/src/test/java/com/example/extractorservice/service/ExtractorServiceWorkflowTest.java
@@ -1,0 +1,55 @@
+package com.example.extractorservice.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.extractorservice.adapter.ExtractorAdapter;
+import com.example.extractorservice.factory.ExtractorServiceFactory;
+
+@ExtendWith(MockitoExtension.class)
+class ExtractorServiceWorkflowTest {
+
+    @Mock
+    private ExtractorServiceFactory factory;
+
+    @Mock
+    private ExtractorAdapter adapter;
+
+    private ExtractorService extractorService;
+
+    @BeforeEach
+    void setUp() {
+        when(factory.getAdapter()).thenReturn(adapter);
+        extractorService = new ExtractorService(factory);
+        extractorService.init();
+    }
+
+    @Test
+    void executeWorkflow_shouldDownloadUploadAndShare() {
+        String sourceUrl = "https://public.example.com/calendar.ics?signature=abc";
+        String destinationRemote = "my-bucket/raw/job-2026-03-12-001/calendar.ics";
+        int expirationTime = 3600;
+        byte[] content = "BEGIN:VCALENDAR".getBytes();
+        String sharedUrl = "https://bucket.example.com/calendar.ics?signature=xyz";
+
+        when(adapter.download(sourceUrl)).thenReturn(content);
+        when(adapter.share(destinationRemote, expirationTime)).thenReturn(sharedUrl);
+
+        String result = extractorService.executeWorkflow(sourceUrl, destinationRemote, expirationTime);
+
+        InOrder inOrder = inOrder(adapter);
+        inOrder.verify(adapter).download(sourceUrl);
+        inOrder.verify(adapter).upload(destinationRemote, content);
+        inOrder.verify(adapter).share(destinationRemote, expirationTime);
+
+        assertEquals(sharedUrl, result);
+    }
+}

--- a/src/test/java/com/example/extractorservice/service/ExtractorServiceWorkflowTest.java
+++ b/src/test/java/com/example/extractorservice/service/ExtractorServiceWorkflowTest.java
@@ -16,6 +16,7 @@ import com.example.extractorservice.factory.ExtractorServiceFactory;
 
 @ExtendWith(MockitoExtension.class)
 class ExtractorServiceWorkflowTest {
+    private static final int DEFAULT_WORKFLOW_EXPIRATION_TIME = 3600;
 
     @Mock
     private ExtractorServiceFactory factory;
@@ -36,19 +37,18 @@ class ExtractorServiceWorkflowTest {
     void executeWorkflow_shouldDownloadUploadAndShare() {
         String sourceUrl = "https://public.example.com/calendar.ics?signature=abc";
         String destinationRemote = "my-bucket/raw/job-2026-03-12-001/calendar.ics";
-        int expirationTime = 3600;
         byte[] content = "BEGIN:VCALENDAR".getBytes();
         String sharedUrl = "https://bucket.example.com/calendar.ics?signature=xyz";
 
         when(adapter.download(sourceUrl)).thenReturn(content);
-        when(adapter.share(destinationRemote, expirationTime)).thenReturn(sharedUrl);
+        when(adapter.share(destinationRemote, DEFAULT_WORKFLOW_EXPIRATION_TIME)).thenReturn(sharedUrl);
 
-        String result = extractorService.executeWorkflow(sourceUrl, destinationRemote, expirationTime);
+        String result = extractorService.executeWorkflow(sourceUrl, destinationRemote);
 
         InOrder inOrder = inOrder(adapter);
         inOrder.verify(adapter).download(sourceUrl);
         inOrder.verify(adapter).upload(destinationRemote, content);
-        inOrder.verify(adapter).share(destinationRemote, expirationTime);
+        inOrder.verify(adapter).share(destinationRemote, DEFAULT_WORKFLOW_EXPIRATION_TIME);
 
         assertEquals(sharedUrl, result);
     }


### PR DESCRIPTION
## Summary

This PR implements the Sprint 001 extract workflow and adds the first end-to-end path for taking a public or pre-signed file URL, storing the file in the target bucket, and returning a new shared URL.

## What was done

- Added support for downloading files from public or pre-signed `http/https` URLs through a new `RemoteDownloadHelper`.
- Integrated remote URL download support into the active storage adapters used by the service.
- Added a new single-call endpoint: `POST /api/workflows/extract`.
- Implemented the workflow in the service layer as:
  `download(sourceUrl) -> upload(destinationRemote, bytes) -> share(destinationRemote, 3600)`.
- Removed `expirationTime` from the workflow endpoint parameters and moved to a default server-side workflow expiration.
- Added validation to ensure source URLs start with `http://` or `https://`.
- Added `@ConditionalOnProperty` on provider adapters so only the configured implementation is loaded.
- Added a manual helper script to execute the extract workflow from the command line.

## Tests

- Added unit tests for `RemoteDownloadHelper`.
- Added workflow service tests to verify the `download -> upload -> share` execution order and returned shared URL.

## Documentation

- Added Sprint 001 extract workflow documentation.
- Documented the new single-call workflow endpoint and manual 3-step flow.
- Added a communication contract sequence diagram for the ETL/MQTT workflow.
- Updated the docs to reflect the latest workflow behavior and parameters.

## Notes

- This PR is focused on the technical relay for Sprint 001 only: download the raw file, upload it unchanged, and return a shared URL.
- Parsing, transformation, business rules, and MQTT-based orchestration remain out of scope for this sprint.
